### PR TITLE
ecbuild handles wrfhydropy package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The workflow uses Github Submodules to obtain all the required repositories.
 All executables will now be in the `build/bin` directory.
 The user can choose to call `jedi_workflowpy.py` from the `build/bin`
   directory or from the `src/jedi_workflowpy` directory.
-
+Note: if the user is not using a [virtual environment](https://docs.python.org/3/library/venv.html) or [conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) then ecbuild will install the required `wrfhydropy` Python library and it's requirements under the user's home directory.
 
 # Cheyenne Build and Run Instructions
 ## Setup Environment
@@ -27,6 +27,7 @@ module use $JEDI_OPT/modulefiles/core
 module load jedi/gnu-openmpi
 module load atlas/ecmwf-0.29.0
 ```
+The user can also add the commands to load their Python virtual environment or Conda environment into the above `gnu_env.sh` file.
 <!-- Old Instructions for Spack -->
 <!--  - Load Spack modules -->
 <!-- module purge -->

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -15,13 +15,21 @@ ecbuild_requires_macro_version( 2.5 )
 
 ecbuild_declare_project()
 ecbuild_enable_fortran( REQUIRED )
-ecbuild_find_python( REQUIRED )
+ecbuild_find_python( VERSION 3.6 REQUIRED NO_LIBS )
 ecbuild_find_mpi(
     COMPONENTS C Fortran
     REQUIRED )
 find_package( NetCDF REQUIRED COMPONENTS Fortran )
 
 enable_testing()
+
+# --- setup Python requirements ---
+if(DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+  set(_pip_args)
+else()
+  set(_pip_args "--user")
+endif()
+execute_process(COMMAND ${Python_EXECUTABLE} -m pip install ${_pip_args} wrfhydropy)
 
 # --- add and update submodules ---
 find_package(Git QUIET)


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: build system, python package requirements, ecbuild

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: The ecbuild system will now handle the installation of the required wrfhydropy Python package. Added notes on this into the README, linking to the virtual environment and conda environment websites to indicate that user's can use those options to manage the Python dependencies and where they get installed.
