### PR TITLE
fix to ctest that is supposed to pass on failure

### DIFF
--- a/src/jedi_increment/jedi_incr.f90
+++ b/src/jedi_increment/jedi_incr.f90
@@ -539,7 +539,7 @@ contains
     else
        write(error_unit, *) "ERROR: passed increment '" // &
             trim(increment_arg) // "' is not SNOWH or SNEQV"
-       stop "ERROR: non-valid increment option passed"
+       error stop "ERROR: non-valid increment option passed"
 
     end if
   end subroutine increment_snowh_or_sneqv

--- a/tests/jedi_increment/CMakeLists.txt
+++ b/tests/jedi_increment/CMakeLists.txt
@@ -34,3 +34,6 @@ add_test(NAME bad_increment_name_passed
   ${CMAKE_CURRENT_BINARY_DIR}/RESTART.2017010100_DOMAIN1.test2
   ${CMAKE_CURRENT_BINARY_DIR}/RESTART.2017010100_DOMAIN1_SNEQV_plus100
   temp)
+
+set_tests_properties(bad_increment_name_passed
+  PROPERTIES WILL_FAIL TRUE)


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: CI, ctests

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES:  fixing the ctest that is supposed to pass on failure